### PR TITLE
Fix permissions for openshift

### DIFF
--- a/icescrum/Dockerfile
+++ b/icescrum/Dockerfile
@@ -9,6 +9,8 @@ RUN chmod 755 /icescrum/startup.sh
 
 RUN wget -O /icescrum/icescrum.jar https://www.icescrum.com/downloads/v7/icescrum.jar
 
+RUN chmod 775 /icescrum && chmod 775 /root
+
 WORKDIR /icescrum
 
 CMD ./startup.sh


### PR DESCRIPTION
I have realized permissions errors while putting the docker into minishift.

touch: cannot touch 'log_file': Permission denied

ERROR org.icescrum.core.support.ApplicationSupport  - Error (exception) could not create file: /icescrum/?/icescrum/appID.txt please check directory & user permission.

Chaging permissions in the dockerfile can fix.